### PR TITLE
chore: Remove validate_manifest hook from pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,11 +27,6 @@ repos:
         args: [--fix, --exit-non-zero-on-fix, --show-fixes]
       - id: ruff-format
 
-  - repo: https://github.com/pre-commit/pre-commit
-    rev: v4.6.0
-    hooks:
-      - id: validate_manifest
-
   - repo: https://github.com/python-jsonschema/check-jsonschema
     rev: 0.37.2
     hooks:


### PR DESCRIPTION
Removed the validate_manifest hook from pre-commit configuration.